### PR TITLE
Add heuristic for CP2&3 binary location on macOS

### DIFF
--- a/org.knime.knip.cellprofiler/src/org/knime/knip/cellprofiler/CellProfilerPreferencePage.java
+++ b/org.knime.knip.cellprofiler/src/org/knime/knip/cellprofiler/CellProfilerPreferencePage.java
@@ -104,7 +104,7 @@ public class CellProfilerPreferencePage extends PreferencePage implements
 
 		if ((OS.indexOf("mac") >= 0) || (OS.indexOf("darwin") >= 0)) {
 			command[0] = "";
-			command[1] = path;
+			command[1] = guessMacOSBinaryFromPath(path);
 		} else if (OS.indexOf("win") >= 0) {
 			command[0] = "";
 			command[1] = path + "CellProfiler.exe";
@@ -122,6 +122,15 @@ public class CellProfilerPreferencePage extends PreferencePage implements
 
 	private static String getOS() {
 		return System.getProperty("os.name", "generic").toLowerCase();
+	}
+
+	private static String guessMacOSBinaryFromPath(final String path) {
+		if (new File(path + "Contents/MacOS/CellProfiler").isFile()) {
+			// Path to CellProfiler 2.x binary
+			return path + "Contents/MacOS/CellProfiler";
+		}
+		// Path to CellProfiler 3.x binary
+		return path + "Contents/MacOS/cp";
 	}
 
 	private static String doAutoGuessCellProfilerPath() {


### PR DESCRIPTION
Trying to execute an application package directly leads to an obscure/misleading permission error. This PR introduces a heuristic for the binary location within the application packages of CellProfiler 2.x and 3.x on macOS.

Aforementioned permission error:
```
ERROR CellProfiler Pipeline Executor 0:2   Cannot run program "/Applications/CellProfiler-3.1.5.app/": error=13, Permission denied
```